### PR TITLE
make numbered list continue

### DIFF
--- a/docs/plink.md
+++ b/docs/plink.md
@@ -98,9 +98,9 @@ We will need three files:
 1. The base data file: **Height.QC.Transformed**
 2. A file containing SNP IDs and their corresponding P-values (`$3` because SNP ID is located in the third column; `$8` because the P-value is located in the eighth column)
 
-```awk
-awk '{print $3,$8}' Height.QC.Transformed > SNP.pvalue
-```
+    ```awk
+    awk '{print $3,$8}' Height.QC.Transformed > SNP.pvalue
+    ```
 
 3. A file containing the different P-value thresholds for inclusion of SNPs in the PRS. Here calculate PRS corresponding to a few thresholds for illustration purposes:
 


### PR DESCRIPTION
without indent, the third item would restart with 1, 
![image](https://user-images.githubusercontent.com/13688320/214211645-30c2fd7b-4e6a-4a6d-a9c4-d2c7a3e10ba2.png)

see also: https://stackoverflow.com/questions/18088955/markdown-continue-numbered-list